### PR TITLE
Fixes error when calling localtime_s in MetarObservationTime.

### DIFF
--- a/Source/Meteorology/Source/Metar.cpp
+++ b/Source/Meteorology/Source/Metar.cpp
@@ -85,14 +85,14 @@ public:
 MetarObservationTime::MetarObservationTime()
 {
     time_t t = time(0);
-    struct tm *now = nullptr;
-    localtime_s(now, &t);
+    struct tm now;
+    auto result = localtime_s(&now, &t);
 
-    if (now != nullptr)
+    if (result != EINVAL)
     {
-        m_dayOfMonth = now->tm_mon;
-        m_hourOfDay = now->tm_hour;
-        m_minuteOfHour = now->tm_min;
+        m_dayOfMonth = now.tm_mon;
+        m_hourOfDay = now.tm_hour;
+        m_minuteOfHour = now.tm_min;
     }
     else
     {


### PR DESCRIPTION
Fixes error when calling localtime_s in MetarObservationTime (resolves issue #7).
